### PR TITLE
Pull request: one typo and two unexported fields

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,7 +62,7 @@ Where:
     )
 
     func Hello(env mango.Env) (mango.Status, mango.Headers, mango.Body) {
-      env.Logger().Println("Got a", env.Request().Method, "request for", env.Request().RawUrl)
+      env.Logger().Println("Got a", env.Request().Method, "request for", env.Request().RawURL)
       return 200, mango.Headers{}, mango.Body("Hello World!")
     }
 

--- a/examples/logger.go
+++ b/examples/logger.go
@@ -10,7 +10,7 @@ func Hello(env mango.Env) (mango.Status, mango.Headers, mango.Body) {
 
 func main() {
 	stack := new(mango.Stack)
-	stack.address = ":3000"
+	stack.Address = ":3000"
 	custom_logger := log.New(os.Stdout, "", log.Ldate|log.Ltime)
 	stack.Middleware(mango.Logger(custom_logger))
 	stack.Run(Hello)

--- a/examples/routing.go
+++ b/examples/routing.go
@@ -16,7 +16,7 @@ func Goodbye(env mango.Env) (mango.Status, mango.Headers, mango.Body) {
 
 func main() {
 	stack := new(mango.Stack)
-	stack.address = ":3000"
+	stack.Address = ":3000"
 
 	// Route all requests for /goodbye to the Goodbye handler
 	routes := map[string]mango.App{"/goodbye(.*)": Goodbye}


### PR DESCRIPTION
Typo in README references RawUrl, should be RawURL for *http.   Two examples reference unexported address field, instead of Address.  Mango looks great, can't wait to wire up some of my own middleware.
