### PR TITLE
Fixed app.Call call in docs and examples

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,7 +120,7 @@ An extremely basic middleware package is simply a function:
 
     func SilenceErrors(env mango.Env, app mango.App) (mango.Status, mango.Headers, mango.Body) {
       // Call our upstream app
-      status, headers, body := app.Call(env)
+      status, headers, body := app(env)
 
       // If we got an error
       if status == 500 {

--- a/examples/silence_middleware.go
+++ b/examples/silence_middleware.go
@@ -6,7 +6,7 @@ import (
 
 func SilenceErrors(env mango.Env, app mango.App) (mango.Status, mango.Headers, mango.Body) {
 	// Call our upstream app
-	status, headers, body := app.Call(env)
+	status, headers, body := app(env)
 
 	// If we got an error
 	if status == 500 {


### PR DESCRIPTION
I noticed that app.Call in silence_middleware must be app()
