### PR TITLE
improve performance for not Set-Cookie all the time

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -172,9 +172,12 @@ func sessionCookieValue(env Env, key string) (value string) {
 func cookieChanged(env Env, key, secret string) string {
 	oldCookieValue := sessionCookieValue(env, key)
 	value := env["mango.session"].(map[string]interface{})
-	if len(value) == 0 {
+
+	// old and new both are empty
+	if oldCookieValue == "" && len(value) == 0 {
 		return ""
 	}
+
 	newCookieValue := encodeCookie(value, secret)
 	if oldCookieValue == newCookieValue {
 		return ""


### PR DESCRIPTION
1. If session doesn't change, which is most of the case, it should't Set-Cookie all the time.
   So that nginx can do proxy cache correctly.
2. Using map for session store make it impossible to compare old cookie and new cookie are the same. because of map are random accessed.
