### PR TITLE
Inject regex matches into environment

### DIFF
--- a/routing.go
+++ b/routing.go
@@ -42,10 +42,11 @@ func Routing(routes map[string]App) Middleware {
 	}
 
 	return func(env Env, app App) (Status, Headers, Body) {
-		path := []byte(env.Request().URL.Path)
 		for i, matcher := range matchers {
-			if matcher.Match(path) {
-				// Matched a route return it
+			matches := matcher.FindStringSubmatch(env.Request().URL.Path)
+			if len(matches) != 0 {
+				// Matched a route; inject matches and return handler
+				env["Routing.matches"] = matches
 				return handlers[i](env)
 			}
 		}

--- a/routing_test.go
+++ b/routing_test.go
@@ -17,12 +17,21 @@ func routingBTestServer(env Env) (Status, Headers, Body) {
 	return 200, Headers{}, Body("Server B")
 }
 
+func routingCTestServer(env Env) (Status, Headers, Body) {
+	if env["Routing.matches"].([]string)[1] == "123" {
+		return 200, Headers{}, Body("Server C")
+	}
+
+	return 500, Headers{}, Body("Test Failed")
+}
+
 func TestRoutingSuccess(t *testing.T) {
 	// Compile the stack
 	routingStack := new(Stack)
 	routes := make(map[string]App)
 	routes["/a"] = routingATestServer
 	routes["/b"] = routingBTestServer
+	routes["/c/(.*)"] = routingCTestServer
 	routingStack.Middleware(Routing(routes))
 	routingApp := routingStack.Compile(routingTestServer)
 
@@ -56,6 +65,23 @@ func TestRoutingSuccess(t *testing.T) {
 	}
 
 	expected = "Server B"
+	if string(body) != expected {
+		t.Error("Expected body:", string(body), "to equal:", expected)
+	}
+
+	// Request against C
+	request, err = http.NewRequest("GET", "http://localhost:3000/c/123", nil)
+	status, _, body = routingApp(Env{"mango.request": &Request{request}})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if status != 200 {
+		t.Error("Expected status to equal 200, got:", status)
+	}
+
+	expected = "Server C"
 	if string(body) != expected {
 		t.Error("Expected body:", string(body), "to equal:", expected)
 	}


### PR DESCRIPTION
Injecting the matches allows handlers to use the matched strings in
their logic (e.g. to lookup data by an ID).
