### PR TITLE
Fixed typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -31,7 +31,7 @@ Where:
 
 ## Installation
 
-   $ goinstall github.com/paulbellamy/mango
+   $ go install github.com/paulbellamy/mango
 
 
 ## Available Modules


### PR DESCRIPTION
It should be go install, not goinstall.
